### PR TITLE
Update dependency campaignmonitor/createsend-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/symfony": ">=2.4.0",
-        "campaignmonitor/createsend-php": "^4.1"
+        "campaignmonitor/createsend-php": "^5.1"
     },
     "autoload": {
         "psr-4": { "Intracto\\CampaignMonitorBundle\\": "" }


### PR DESCRIPTION
campaignmonitor/createsend-php 4.1 has deprecated constructors causing warnings in PHP >=7.0